### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+FROM python:3.7-slim
+ENV PYTHONUNBUFFERED 1
+
+# Create a group and user to run our app
+ARG APP_USER=appuser
+RUN groupadd -r ${APP_USER} && useradd --no-log-init -r -g ${APP_USER} ${APP_USER}
+
+# Install packages needed to run your application (not build deps):
+#   mime-support -- for mime types when serving static files
+#   postgresql-client -- for running database commands
+# We need to recreate the /usr/share/man/man{1..8} directories first because
+# they were clobbered by a parent image.
+RUN set -ex \
+    && RUN_DEPS=" \
+    ca-certificates \
+    curl \
+    libpcre3 \
+    mime-support \
+    postgresql-client \
+    " \
+    && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
+    && apt-get update && apt-get install -y --no-install-recommends $RUN_DEPS \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install supervisord
+RUN mkdir -p /etc/supervisord/conf.d \
+    && mkdir /var/log/supervisord \
+    && pip install supervisor \
+    && pip install supervisor-stdout
+
+# Copy in your requirements file
+ADD requirements.txt /requirements.txt
+
+# OR, if you're using a directory for your requirements, copy everything (comment out the above and uncomment this if so):
+# ADD requirements /requirements
+
+# Install build deps, then run `pip install`, then remove unneeded build deps all in a single step.
+# Correct the path to your production requirements file, if needed.
+RUN set -ex \
+    && BUILD_DEPS=" \
+    build-essential \
+    libpcre3-dev \
+    libpq-dev \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS \
+    && pip install --no-cache-dir -r /requirements.txt \
+    \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy your application code to the container (make sure you create a .dockerignore file if any large files or directories should be excluded)
+RUN mkdir /app/
+ADD . /app/
+WORKDIR /app/
+
+# uWSGI will listen on this port
+EXPOSE 8008
+
+# Add any static environment variables needed by Django or your settings file here:
+# ENV DJANGO_SETTINGS_MODULE=my_project.settings.deploy
+
+# Call collectstatic (customize the following line with the minimal environment variables needed for manage.py to run):
+RUN DATABASE_URL='' STATIC_ROOT=/app/static python manage.py collectstatic --noinput
+
+# Tell uWSGI where to find your wsgi file (change this):
+ENV UWSGI_WSGI_FILE=standup/wsgi.py
+
+# Base uWSGI configuration (you shouldn't need to change these):
+ENV UWSGI_HTTP=:8008 UWSGI_MASTER=1 UWSGI_HTTP_AUTO_CHUNKED=1 UWSGI_HTTP_KEEPALIVE=1 UWSGI_LAZY_APPS=1 UWSGI_WSGI_ENV_BEHAVIOR=holy
+
+# Number of uWSGI workers and threads per worker (customize as needed):
+ENV UWSGI_WORKERS=2 UWSGI_THREADS=4
+
+# uWSGI static file serving configuration (customize or comment out if not needed):
+ENV UWSGI_STATIC_MAP="/static/=/app/static/" UWSGI_STATIC_EXPIRES_URI="/static/.*\.[a-f0-9]{12,}\.(css|js|png|jpg|jpeg|gif|ico|woff|ttf|otf|svg|scss|map|txt) 315360000"
+
+# Deny invalid hosts before they get to Django (uncomment and change to your hostname(s)):
+# ENV UWSGI_ROUTE_HOST="^(?!localhost:8000$) break:400"
+
+# Change to a non-root user
+USER ${APP_USER}:${APP_USER}
+
+# Uncomment after creating your docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+COPY supervisord.conf /etc/supervisord/
+
+# Start supervisord
+CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord/supervisord.conf"]
+
+# Start uWSGI
+#CMD ["uwsgi", "--show-config"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+services:
+  db:
+    image: postgres
+    restart: always
+    env_file: .env
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  web:
+    build: .
+    #command: python manage.py runserver 0.0.0.0:8008
+    restart: always
+    env_file: .env
+    ports:
+      - "8008:8008"
+    depends_on:
+      - db
+
+volumes:
+  db-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+export PGDATABASE=${DATABASE_NAME}
+export PGUSER=${DATABASE_USER}
+export PGPASSWORD=${DATABASE_PASSWORD}
+export PGHOST=${DATABASE_HOST}
+export PGPORT=${DATABASE_PORT}
+
+until psql -l; do
+    >&2 echo "Postgres is unavailable - sleeping"
+    sleep 1
+done
+
+>&2 echo "Postgres is up - continuing"
+
+if [ "x$DJANGO_MANAGEPY_MIGRATE" = 'xon' ]; then
+    python manage.py migrate --noinput
+fi
+
+exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,5 @@ sqlparse==0.3.0
 traitlets==4.3.3
 wcwidth==0.1.7
 websockets==6.0
+uwsgi>=2.0,<2.1
 yarl==1.3.0

--- a/standup/settings.py
+++ b/standup/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 # Quick-start development settings - unsuitable for production

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,30 @@
+[supervisord]
+nodaemon = true
+pidfile = /tmp/supervisord.pid
+logfile=/dev/stdout
+logfile_maxbytes=0
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+
+[include]
+files = /etc/supervisord/conf.d/*.conf
+
+[program:web]
+command=uwsgi --show-config
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[program:bot]
+command=python manage.py run_bot
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[eventlistenter:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
- The docker-compose file to manage web and db containers
- Uses supervisord in web container to manage bot and web processes
- Web server uses uwsgi
- Docker entrypoint script automatically runs migrations at start time if env DJANGO_MANAGEPY_MIGRATE is set to 'on'
- Had to change BASE_DIR in settings.py to fix a bug with `collectstatic` at container build time